### PR TITLE
Add local development setup

### DIFF
--- a/docker-compose/local_dev/chains.json
+++ b/docker-compose/local_dev/chains.json
@@ -1,0 +1,10 @@
+{
+    "6d3ce011e06e27a74cfa7d774228c52597ef5ef26f4a4afa9ad3cebefb5f3ca8": {
+        "addr": "6d3ce011e06e27a74cfa7d774228c52597ef5ef26f4a4afa9ad3cebefb5f3ca8",
+        "url": "geth-mainnet:8545"
+    },
+    "49aff8a9f51b268f6fc485ec14fb08466c3ec68c8d86d9b5810ad80546b65f29": {
+        "addr": "49aff8a9f51b268f6fc485ec14fb08466c3ec68c8d86d9b5810ad80546b65f29",
+        "url": "geth-rinkeby:8545"
+    }
+}

--- a/docker-compose/local_dev/docker-compose.yml
+++ b/docker-compose/local_dev/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     build: ../../docker
     ports:
       - "8081:8081"
+      - "26657:26657"
     expose:
       - "8081"  #  POKT RPC
       - "26657" #  Tendermint RPC
@@ -15,14 +16,13 @@ services:
       - "46656" #  Tendermint Peers
     environment:
       POCKET_CORE_KEY: "b8a56dead392e2b57eaba988068d0cedc0a11b9a16ca9610b094ec31a9cbc06650220553e5ccf56a863eaed88ebf1487e1dcb20e7fffbe0fb841cab1bb76af4d"
-      POCKET_CORE_PERSISTENT_PEERS: "3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
       POCKET_CORE_SEEDS: "3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
     networks:
       - pocket
     volumes:
         - "./local_command.sh:/home/app/.pocket/local_command.sh"
-        - "./chains.json:/home/app/.pocket/chains.json"
-        - "./genesis.json:/home/app/.pocket/genesis.json"
+        - "./chains.json:/home/app/.pocket/config/chains.json"
+        - "./genesis.json:/home/app/.pocket/config/genesis.json"
 
   pocket-core-testnet2:
     image: poktnetwork/pocket-core:${ENV:-staging-latest}
@@ -36,14 +36,13 @@ services:
       - "46656" #  Tendermint Peers
     environment:
       POCKET_CORE_KEY: "a49ff628a250c2d8e9a8e6dff2c86c075a5f0b22c489ac5d8a0b47392b02052bff1e6080925587cd76974710b14d1c2229aed4442921ccd67b7c97fece399ebe"
-      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
       POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
     networks:
       - pocket
     volumes:
         - "./local_command.sh:/home/app/.pocket/local_command.sh"
-        - "./chains.json:/home/app/.pocket/chains.json"
-        - "./genesis.json:/home/app/.pocket/genesis.json"
+        - "./chains.json:/home/app/.pocket/config/chains.json"
+        - "./genesis.json:/home/app/.pocket/config/genesis.json"
 
   pocket-core-testnet3:
     image: poktnetwork/pocket-core:${ENV:-staging-latest}
@@ -57,14 +56,13 @@ services:
       - "46656" #  Tendermint Peers
     environment:
       POCKET_CORE_KEY: "44cb0f6fcaac7bb3199bcb3c8548dbebeeef9746441449db1515a3f890ccfcf24f26a1d836d8d421007bcb20a67b4afc70511cac6a0975347e430140d80741ee"
-      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
       POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
     networks:
       - pocket
     volumes:
         - "./local_command.sh:/home/app/.pocket/local_command.sh"
-        - "./chains.json:/home/app/.pocket/chains.json"
-        - "./genesis.json:/home/app/.pocket/genesis.json"
+        - "./chains.json:/home/app/.pocket/config/chains.json"
+        - "./genesis.json:/home/app/.pocket/config/genesis.json"
 
   pocket-core-testnet4:
     image: poktnetwork/pocket-core:${ENV:-staging-latest}
@@ -78,14 +76,13 @@ services:
       - "46656" #  Tendermint Peers
     environment:
       POCKET_CORE_KEY: "11c1eb0da2fd2bc6aef9ab45cb2576807cd00e4147ea8388900860a2eed236078ab9c7a3b341bc071ad2f11e84c695812fe5c2771524b89ae1131cae48d93c8f"
-      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:46656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:46656"
       POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
     networks:
       - pocket
     volumes:
         - "./local_command.sh:/home/app/.pocket/local_command.sh"
-        - "./chains.json:/home/app/.pocket/chains.json"
-        - "./genesis.json:/home/app/.pocket/genesis.json"
+        - "./chains.json:/home/app/.pocket/config/chains.json"
+        - "./genesis.json:/home/app/.pocket/config/genesis.json"
 
   pocket-core-testnet5:
     image: poktnetwork/pocket-core:${ENV:-staging-latest}
@@ -99,14 +96,13 @@ services:
       - "46656" #  Tendermint Peers
     environment:
       POCKET_CORE_KEY: "b7f2d96ef6f3b7b7e54fdf9dba81e3912c7d45d43785138c3be47c885009d3e09b1be29dd2c546244f13d9cb3abf9202707494286bf8d440f3e75f6dba30c57a"
-      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656"
       POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656"
     networks:
       - pocket
     volumes:
         - "./local_command.sh:/home/app/.pocket/local_command.sh"
-        - "./chains.json:/home/app/.pocket/chains.json"
-        - "./genesis.json:/home/app/.pocket/genesis.json"
+        - "./chains.json:/home/app/.pocket/config/chains.json"
+        - "./genesis.json:/home/app/.pocket/config/genesis.json"
 
 networks:
   pocket:

--- a/docker-compose/local_dev/docker-compose.yml
+++ b/docker-compose/local_dev/docker-compose.yml
@@ -1,0 +1,98 @@
+version: '2.1'
+
+services:
+  pocket-core-testnet:
+    image: poktnetwork/pocket-core:${ENV:-staging-latest}
+    privileged: true
+    command: "/usr/bin/expect /home/app/command.sh"
+    build: ../../docker
+    ports:
+      - "8081:8081"
+    expose:
+      - "8081"  #  POKT RPC
+      - "26657" #  Tendermint RPC
+      - "46656" #  Tendermint Peers
+    environment:
+      POCKET_CORE_KEY: "b8a56dead392e2b57eaba988068d0cedc0a11b9a16ca9610b094ec31a9cbc06650220553e5ccf56a863eaed88ebf1487e1dcb20e7fffbe0fb841cab1bb76af4d"
+      POCKET_CORE_PERSISTENT_PEERS: "3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:46656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:46656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:46656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:46656"
+    networks:
+      - pocket
+    volumes:
+        - "./chains.json:/home/app/.pocket/chains.json"
+        - "./genesis.json:/home/app/.pocket/genesis.json"
+
+  pocket-core-testnet2:
+    image: poktnetwork/pocket-core:${ENV:-staging-latest}
+    privileged: true
+    command: "/usr/bin/expect /home/app/command.sh"
+    build: ../../docker
+    expose:
+      - "8081"  #  POKT RPC
+      - "26657" #  Tendermint RPC
+      - "46656" #  Tendermint Peers
+    environment:
+      POCKET_CORE_KEY: "a49ff628a250c2d8e9a8e6dff2c86c075a5f0b22c489ac5d8a0b47392b02052bff1e6080925587cd76974710b14d1c2229aed4442921ccd67b7c97fece399ebe"
+      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:46656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:46656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:46656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:46656"
+    networks:
+      - pocket
+    volumes:
+        - "./chains.json:/home/app/.pocket/chains.json"
+        - "./genesis.json:/home/app/.pocket/genesis.json"
+
+  pocket-core-testnet3:
+    image: poktnetwork/pocket-core:${ENV:-staging-latest}
+    privileged: true
+    command: "/usr/bin/expect /home/app/command.sh"
+    build: ../../docker
+    expose:
+      - "8081"  #  POKT RPC
+      - "26657" #  Tendermint RPC
+      - "46656" #  Tendermint Peers
+    environment:
+      POCKET_CORE_KEY: "44cb0f6fcaac7bb3199bcb3c8548dbebeeef9746441449db1515a3f890ccfcf24f26a1d836d8d421007bcb20a67b4afc70511cac6a0975347e430140d80741ee"
+      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:46656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:46656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:46656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:46656"
+    networks:
+      - pocket
+    volumes:
+        - "./chains.json:/home/app/.pocket/chains.json"
+        - "./genesis.json:/home/app/.pocket/genesis.json"
+
+  pocket-core-testnet4:
+    image: poktnetwork/pocket-core:${ENV:-staging-latest}
+    privileged: true
+    command: "/usr/bin/expect /home/app/command.sh"
+    build: ../../docker
+    expose:
+      - "8081"  #  POKT RPC
+      - "26657" #  Tendermint RPC
+      - "46656" #  Tendermint Peers
+    environment:
+      POCKET_CORE_KEY: "11c1eb0da2fd2bc6aef9ab45cb2576807cd00e4147ea8388900860a2eed236078ab9c7a3b341bc071ad2f11e84c695812fe5c2771524b89ae1131cae48d93c8f"
+      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:46656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:46656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:46656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:46656"
+    networks:
+      - pocket
+    volumes:
+        - "./chains.json:/home/app/.pocket/chains.json"
+        - "./genesis.json:/home/app/.pocket/genesis.json"
+
+  pocket-core-testnet5:
+    image: poktnetwork/pocket-core:${ENV:-staging-latest}
+    privileged: true
+    command: "/usr/bin/expect /home/app/command.sh"
+    build: ../../docker
+    expose:
+      - "8081"  #  POKT RPC
+      - "26657" #  Tendermint RPC
+      - "46656" #  Tendermint Peers
+    environment:
+      POCKET_CORE_KEY: "b7f2d96ef6f3b7b7e54fdf9dba81e3912c7d45d43785138c3be47c885009d3e09b1be29dd2c546244f13d9cb3abf9202707494286bf8d440f3e75f6dba30c57a"
+      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:46656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:46656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:46656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:46656"
+    networks:
+      - pocket
+    volumes:
+        - "./chains.json:/home/app/.pocket/chains.json"
+        - "./genesis.json:/home/app/.pocket/genesis.json"
+
+networks:
+  pocket:
+    driver: bridge

--- a/docker-compose/local_dev/docker-compose.yml
+++ b/docker-compose/local_dev/docker-compose.yml
@@ -4,92 +4,107 @@ services:
   pocket-core-testnet:
     image: poktnetwork/pocket-core:${ENV:-staging-latest}
     privileged: true
-    command: "/usr/bin/expect /home/app/command.sh"
+    command: "/usr/bin/expect /home/app/.pocket/local_command.sh"
     build: ../../docker
     ports:
       - "8081:8081"
     expose:
       - "8081"  #  POKT RPC
       - "26657" #  Tendermint RPC
+      - "26656"
       - "46656" #  Tendermint Peers
     environment:
       POCKET_CORE_KEY: "b8a56dead392e2b57eaba988068d0cedc0a11b9a16ca9610b094ec31a9cbc06650220553e5ccf56a863eaed88ebf1487e1dcb20e7fffbe0fb841cab1bb76af4d"
-      POCKET_CORE_PERSISTENT_PEERS: "3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:46656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:46656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:46656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:46656"
+      POCKET_CORE_PERSISTENT_PEERS: "3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
+      POCKET_CORE_SEEDS: "3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
     networks:
       - pocket
     volumes:
+        - "./local_command.sh:/home/app/.pocket/local_command.sh"
         - "./chains.json:/home/app/.pocket/chains.json"
         - "./genesis.json:/home/app/.pocket/genesis.json"
 
   pocket-core-testnet2:
     image: poktnetwork/pocket-core:${ENV:-staging-latest}
     privileged: true
-    command: "/usr/bin/expect /home/app/command.sh"
+    command: "/usr/bin/expect /home/app/.pocket/local_command.sh"
     build: ../../docker
     expose:
       - "8081"  #  POKT RPC
       - "26657" #  Tendermint RPC
+      - "26656"
       - "46656" #  Tendermint Peers
     environment:
       POCKET_CORE_KEY: "a49ff628a250c2d8e9a8e6dff2c86c075a5f0b22c489ac5d8a0b47392b02052bff1e6080925587cd76974710b14d1c2229aed4442921ccd67b7c97fece399ebe"
-      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:46656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:46656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:46656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:46656"
+      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
+      POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
     networks:
       - pocket
     volumes:
+        - "./local_command.sh:/home/app/.pocket/local_command.sh"
         - "./chains.json:/home/app/.pocket/chains.json"
         - "./genesis.json:/home/app/.pocket/genesis.json"
 
   pocket-core-testnet3:
     image: poktnetwork/pocket-core:${ENV:-staging-latest}
     privileged: true
-    command: "/usr/bin/expect /home/app/command.sh"
+    command: "/usr/bin/expect /home/app/.pocket/local_command.sh"
     build: ../../docker
     expose:
       - "8081"  #  POKT RPC
       - "26657" #  Tendermint RPC
+      - "26656"
       - "46656" #  Tendermint Peers
     environment:
       POCKET_CORE_KEY: "44cb0f6fcaac7bb3199bcb3c8548dbebeeef9746441449db1515a3f890ccfcf24f26a1d836d8d421007bcb20a67b4afc70511cac6a0975347e430140d80741ee"
-      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:46656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:46656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:46656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:46656"
+      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
+      POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
     networks:
       - pocket
     volumes:
+        - "./local_command.sh:/home/app/.pocket/local_command.sh"
         - "./chains.json:/home/app/.pocket/chains.json"
         - "./genesis.json:/home/app/.pocket/genesis.json"
 
   pocket-core-testnet4:
     image: poktnetwork/pocket-core:${ENV:-staging-latest}
     privileged: true
-    command: "/usr/bin/expect /home/app/command.sh"
+    command: "/usr/bin/expect /home/app/.pocket/local_command.sh"
     build: ../../docker
     expose:
       - "8081"  #  POKT RPC
       - "26657" #  Tendermint RPC
+      - "26656"
       - "46656" #  Tendermint Peers
     environment:
       POCKET_CORE_KEY: "11c1eb0da2fd2bc6aef9ab45cb2576807cd00e4147ea8388900860a2eed236078ab9c7a3b341bc071ad2f11e84c695812fe5c2771524b89ae1131cae48d93c8f"
-      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:46656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:46656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:46656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:46656"
+      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:46656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:46656"
+      POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
     networks:
       - pocket
     volumes:
+        - "./local_command.sh:/home/app/.pocket/local_command.sh"
         - "./chains.json:/home/app/.pocket/chains.json"
         - "./genesis.json:/home/app/.pocket/genesis.json"
 
   pocket-core-testnet5:
     image: poktnetwork/pocket-core:${ENV:-staging-latest}
     privileged: true
-    command: "/usr/bin/expect /home/app/command.sh"
+    command: "/usr/bin/expect /home/app/.pocket/local_command.sh"
     build: ../../docker
     expose:
       - "8081"  #  POKT RPC
       - "26657" #  Tendermint RPC
+      - "26656"
       - "46656" #  Tendermint Peers
     environment:
       POCKET_CORE_KEY: "b7f2d96ef6f3b7b7e54fdf9dba81e3912c7d45d43785138c3be47c885009d3e09b1be29dd2c546244f13d9cb3abf9202707494286bf8d440f3e75f6dba30c57a"
-      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:46656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:46656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:46656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:46656"
+      POCKET_CORE_PERSISTENT_PEERS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656"
+      POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656"
     networks:
       - pocket
     volumes:
+        - "./local_command.sh:/home/app/.pocket/local_command.sh"
         - "./chains.json:/home/app/.pocket/chains.json"
         - "./genesis.json:/home/app/.pocket/genesis.json"
 

--- a/docker-compose/local_dev/genesis.json
+++ b/docker-compose/local_dev/genesis.json
@@ -1,0 +1,154 @@
+{
+  "genesis_time": "0001-01-01T00:00:00Z",
+  "chain_id": "pocket-test",
+  "consensus_params": {
+    "block": {
+      "max_bytes": "15000",
+      "max_gas": "-1",
+      "time_iota_ms": "1"
+    },
+    "evidence": {
+      "max_age": "1000000"
+    },
+    "validator": {
+      "pub_key_types": [
+        "ed25519"
+      ]
+    }
+  },
+  "app_hash": "",
+  "app_state": {
+    "pos": {
+      "params": {
+        "unstaking_time": "1814400000000000",
+        "max_validators": "100000",
+        "stake_denom": "stake",
+        "stake_minimum": "1",
+        "base_proposer_award": 90,
+        "session_block_frequency": "25",
+        "relays_to_tokens": "0.000100000000000000",
+        "max_evidence_age": "120000000000",
+        "signed_blocks_window": "100",
+        "min_signed_per_window": "0.500000000000000000",
+        "downtime_jail_duration": "600000000000",
+        "slash_fraction_double_sign": "0.050000000000000000",
+        "slash_fraction_downtime": "0.010000000000000000"
+      },
+      "prevState_total_power": "0",
+      "prevState_validator_powers": null,
+      "validators": [
+        {
+          "address": "3dc42932ff52f9f506dce1d75b634ddad654e22e",
+          "public_key": "50220553e5ccf56a863eaed88ebf1487e1dcb20e7fffbe0fb841cab1bb76af4d",
+          "jailed": false,
+          "status": 2,
+          "tokens": "10000000",
+          "service_url": "http://www.pocket-core-testnet0:8081",
+          "chains": [
+            "6d3ce011e06e27a74cfa7d774228c52597ef5ef26f4a4afa9ad3cebefb5f3ca8",
+            "49aff8a9f51b268f6fc485ec14fb08466c3ec68c8d86d9b5810ad80546b65f29"
+          ],
+          "unstaking_time": "0001-01-01T00:00:00Z"
+        },
+        {
+          "address": "3c4ce33e68a726bca3801e99e24f80c10eaf343c",
+          "public_key": "ff1e6080925587cd76974710b14d1c2229aed4442921ccd67b7c97fece399ebe",
+          "jailed": false,
+          "status": 2,
+          "tokens": "10000000",
+          "service_url": "http://www.pocket-core-testnet1:8081",
+          "chains": [
+            "6d3ce011e06e27a74cfa7d774228c52597ef5ef26f4a4afa9ad3cebefb5f3ca8",
+            "49aff8a9f51b268f6fc485ec14fb08466c3ec68c8d86d9b5810ad80546b65f29"
+          ],
+          "unstaking_time": "0001-01-01T00:00:00Z"
+        },
+        {
+          "address": "4bcb7b0e9c3fc3343905260bf36d40979be524cd",
+          "public_key": "4f26a1d836d8d421007bcb20a67b4afc70511cac6a0975347e430140d80741ee",
+          "jailed": false,
+          "status": 2,
+          "tokens": "10000000",
+          "service_url": "http://www.pocket-core-testnet2:8081",
+          "chains": [
+            "6d3ce011e06e27a74cfa7d774228c52597ef5ef26f4a4afa9ad3cebefb5f3ca8",
+            "49aff8a9f51b268f6fc485ec14fb08466c3ec68c8d86d9b5810ad80546b65f29"
+          ],
+          "unstaking_time": "0001-01-01T00:00:00Z"
+        },
+        {
+          "address": "e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e",
+          "public_key": "8ab9c7a3b341bc071ad2f11e84c695812fe5c2771524b89ae1131cae48d93c8f",
+          "jailed": false,
+          "status": 2,
+          "tokens": "10000000",
+          "service_url": "http://www.pocket-core-testnet3:8081",
+          "chains": [
+            "6d3ce011e06e27a74cfa7d774228c52597ef5ef26f4a4afa9ad3cebefb5f3ca8",
+            "49aff8a9f51b268f6fc485ec14fb08466c3ec68c8d86d9b5810ad80546b65f29"
+          ],
+          "unstaking_time": "0001-01-01T00:00:00Z"
+        },
+        {
+          "address": "8ed7a41b06ea855ff4ba3ee630688b73499626ae",
+          "public_key": "9b1be29dd2c546244f13d9cb3abf9202707494286bf8d440f3e75f6dba30c57a",
+          "jailed": false,
+          "status": 2,
+          "tokens": "10000000",
+          "service_url": "http://www.pocket-core-testnet4:8081",
+          "chains": [
+            "6d3ce011e06e27a74cfa7d774228c52597ef5ef26f4a4afa9ad3cebefb5f3ca8",
+            "49aff8a9f51b268f6fc485ec14fb08466c3ec68c8d86d9b5810ad80546b65f29"
+          ],
+          "unstaking_time": "0001-01-01T00:00:00Z"
+        }
+      ],
+      "exported": false,
+      "dao": {
+        "Tokens": "0"
+      },
+      "signing_infos": {},
+      "missed_blocks": {},
+      "previous_proposer": ""
+    },
+    "supply": {
+      "supply": []
+    },
+    "pocketcore": {
+      "params": {
+        "session_node_count": "5",
+        "proof_waiting_period": "3",
+        "supported_blockchains": null,
+        "claim_expiration": "25"
+      },
+      "proofs": null,
+      "claims": null
+    },
+    "application": {
+      "params": {
+        "unstaking_time": "1814400000000000",
+        "max_applications": "100000",
+        "app_stake_minimum": "1",
+        "base_relays_per_pokt": "100",
+        "staking_adjustment": "0",
+        "participation_rate_on": false
+      },
+      "applications": null,
+      "exported": false
+    },
+    "auth": {
+      "params": {
+        "max_memo_characters": "256",
+        "tx_sig_limit": "7",
+        "tx_size_cost_per_byte": "10",
+        "sig_verify_cost_ed25519": "590",
+        "sig_verify_cost_secp256k1": "1000"
+      },
+      "Accounts": null
+    },
+    "bank": {
+      "send_enabled": true
+    },
+    "params": null
+  }
+}

--- a/docker-compose/local_dev/genesis.json
+++ b/docker-compose/local_dev/genesis.json
@@ -1,5 +1,5 @@
 {
-  "genesis_time": "0001-01-01T00:00:00Z",
+  "genesis_time": "2020-02-03T18:45:00Z",
   "chain_id": "pocket-test",
   "consensus_params": {
     "block": {
@@ -42,7 +42,7 @@
           "public_key": "50220553e5ccf56a863eaed88ebf1487e1dcb20e7fffbe0fb841cab1bb76af4d",
           "jailed": false,
           "status": 2,
-          "tokens": "10000000",
+          "tokens": "100000000",
           "service_url": "http://www.pocket-core-testnet0:8081",
           "chains": [
             "6d3ce011e06e27a74cfa7d774228c52597ef5ef26f4a4afa9ad3cebefb5f3ca8",
@@ -55,7 +55,7 @@
           "public_key": "ff1e6080925587cd76974710b14d1c2229aed4442921ccd67b7c97fece399ebe",
           "jailed": false,
           "status": 2,
-          "tokens": "10000000",
+          "tokens": "110000000",
           "service_url": "http://www.pocket-core-testnet1:8081",
           "chains": [
             "6d3ce011e06e27a74cfa7d774228c52597ef5ef26f4a4afa9ad3cebefb5f3ca8",
@@ -94,7 +94,7 @@
           "public_key": "9b1be29dd2c546244f13d9cb3abf9202707494286bf8d440f3e75f6dba30c57a",
           "jailed": false,
           "status": 2,
-          "tokens": "10000000",
+          "tokens": "10005000",
           "service_url": "http://www.pocket-core-testnet4:8081",
           "chains": [
             "6d3ce011e06e27a74cfa7d774228c52597ef5ef26f4a4afa9ad3cebefb5f3ca8",

--- a/docker-compose/local_dev/keys.json
+++ b/docker-compose/local_dev/keys.json
@@ -1,0 +1,27 @@
+[
+  {
+    "private_key": "b8a56dead392e2b57eaba988068d0cedc0a11b9a16ca9610b094ec31a9cbc06650220553e5ccf56a863eaed88ebf1487e1dcb20e7fffbe0fb841cab1bb76af4d",
+    "public_key": "50220553e5ccf56a863eaed88ebf1487e1dcb20e7fffbe0fb841cab1bb76af4d",
+    "address": "3DC42932FF52F9F506DCE1D75B634DDAD654E22E"
+  },
+  {
+    "private_key": "a49ff628a250c2d8e9a8e6dff2c86c075a5f0b22c489ac5d8a0b47392b02052bff1e6080925587cd76974710b14d1c2229aed4442921ccd67b7c97fece399ebe",
+    "public_key": "ff1e6080925587cd76974710b14d1c2229aed4442921ccd67b7c97fece399ebe",
+    "address": "3C4CE33E68A726BCA3801E99E24F80C10EAF343C"
+  },
+  {
+    "private_key": "44cb0f6fcaac7bb3199bcb3c8548dbebeeef9746441449db1515a3f890ccfcf24f26a1d836d8d421007bcb20a67b4afc70511cac6a0975347e430140d80741ee",
+    "public_key": "4f26a1d836d8d421007bcb20a67b4afc70511cac6a0975347e430140d80741ee",
+    "address": "4BCB7B0E9C3FC3343905260BF36D40979BE524CD"
+  },
+  {
+    "private_key": "11c1eb0da2fd2bc6aef9ab45cb2576807cd00e4147ea8388900860a2eed236078ab9c7a3b341bc071ad2f11e84c695812fe5c2771524b89ae1131cae48d93c8f",
+    "public_key": "8ab9c7a3b341bc071ad2f11e84c695812fe5c2771524b89ae1131cae48d93c8f",
+    "address": "E1EC5FBE826BB6DD3CEB04B33BBF221E611C601E"
+  },
+  {
+    "private_key": "b7f2d96ef6f3b7b7e54fdf9dba81e3912c7d45d43785138c3be47c885009d3e09b1be29dd2c546244f13d9cb3abf9202707494286bf8d440f3e75f6dba30c57a",
+    "public_key": "9b1be29dd2c546244f13d9cb3abf9202707494286bf8d440f3e75f6dba30c57a",
+    "address": "8ED7A41B06EA855FF4BA3EE630688B73499626AE"
+  }
+]

--- a/docker-compose/local_dev/local_command.sh
+++ b/docker-compose/local_dev/local_command.sh
@@ -9,7 +9,7 @@ if { $env(POCKET_CORE_KEY) eq "" }  {
     sleep 1
     send -- "yo\n"
     expect eof
-    spawn pocket-core start --persistent_peers $env(POCKET_CORE_PERSISTENT_PEERS) --seeds $env(POCKET_CORE_SEEDS)
+    spawn pocket-core start --seeds $env(POCKET_CORE_SEEDS)
 }
 
 sleep 1

--- a/docker-compose/local_dev/local_command.sh
+++ b/docker-compose/local_dev/local_command.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/expect
+
+set timeout -1
+
+if { $env(POCKET_CORE_KEY) eq "" }  {
+    spawn pocket-core start
+} else {
+    spawn pocket-core accounts import-raw $env(POCKET_CORE_KEY)
+    sleep 1
+    send -- "yo\n"
+    expect eof
+    spawn pocket-core start --persistent_peers $env(POCKET_CORE_PERSISTENT_PEERS) --seeds $env(POCKET_CORE_SEEDS)
+}
+
+sleep 1
+
+send -- "yo\n"
+
+expect eof
+
+exit


### PR DESCRIPTION
- Modify Genesis Time
- Add local setup to run 5 pocket nodes.
- use `--seeds` instead of `--persistent-peers`
- expose a single node ports to allow for RPC calls
- Use default TM Port to run