### PR TITLE
patch/cant-find-peers

### DIFF
--- a/docker-compose/geth/docker-compose-local.yml
+++ b/docker-compose/geth/docker-compose-local.yml
@@ -1,0 +1,133 @@
+version: '2.1'
+
+services:
+
+  geth-rinkeby:
+    image: ethereum/client-go:v1.9.9
+    expose:
+      - "8545"
+      - "8546"
+      - "30303"
+    volumes:
+      - geth-rinkeby:/.rinkeby
+    command: "--rinkeby --rpc --rpcapi eth,net --rpcaddr 0.0.0.0 --rpcport 8545 --rpcvhosts=* --syncmode fast --datadir .rinkeby --verbosity 3"
+    networks:
+      - pocket
+
+  geth-mainnet:
+    image: ethereum/client-go:v1.9.9
+    expose:
+      - "8545"
+      - "8546"
+      - "30303"
+    volumes:
+      - geth-mainnet:/.mainnet
+    command: "--rpc  --rpcapi eth,net --rpcaddr 0.0.0.0 --rpcport 8545 --rpcvhosts=* --syncmode fast --datadir .mainnet --verbosity 3"
+    networks:
+      - pocket
+
+  pocket-core-testnet:
+    image: poktnetwork/pocket-core:${ENV:-staging-latest}
+    privileged: true
+    command: "/usr/bin/expect /home/app/command.sh"
+    build: ../../docker
+    ports:
+      - "8081:8081"   # POKT RPC
+      - "26657:26657" # Tendermint RPC
+    expose:
+      - "8081"  #  POKT RPC
+      - "26657" #  Tendermint RPC
+      - "26656" #  Tendermint Peers
+      - "46656" #  Tendermint Peers
+    environment:
+      POCKET_CORE_KEY: "b8a56dead392e2b57eaba988068d0cedc0a11b9a16ca9610b094ec31a9cbc06650220553e5ccf56a863eaed88ebf1487e1dcb20e7fffbe0fb841cab1bb76af4d"
+      POCKET_CORE_SEEDS: "3C4CE33E68A726BCA3801E99E24F80C10EAF343C@pocket-core-testnet2:26656,  4BCB7B0E9C3FC3343905260BF36D40979BE524CD@pocket-core-testnet3:26656, E1EC5FBE826BB6DD3CEB04B33BBF221E611C601E@pocket-core-testnet4:26656, 8ED7A41B06EA855FF4BA3EE630688B73499626AE@pocket-core-testnet5:26656"
+    networks:
+      - pocket
+    volumes:
+        - "./chains.json:/home/app/.pocket/chains.json"
+        - "./genesis.json:/home/app/.pocket/genesis.json"
+
+  pocket-core-testnet2:
+    image: poktnetwork/pocket-core:${ENV:-staging-latest}
+    privileged: true
+    command: "/usr/bin/expect /home/app/command.sh"
+    build: ../../docker
+    expose:
+      - "8081"  #  POKT RPC
+      - "26657" #  Tendermint RPC
+      - "26656" #  Tendermint Peers
+      - "46656" #  Tendermint Peers
+    environment:
+      POCKET_CORE_KEY: "a49ff628a250c2d8e9a8e6dff2c86c075a5f0b22c489ac5d8a0b47392b02052bff1e6080925587cd76974710b14d1c2229aed4442921ccd67b7c97fece399ebe"
+      POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
+    networks:
+      - pocket
+    volumes:
+        - "./chains.json:/home/app/.pocket/chains.json"
+        - "./genesis.json:/home/app/.pocket/genesis.json"
+
+  pocket-core-testnet3:
+    image: poktnetwork/pocket-core:${ENV:-staging-latest}
+    privileged: true
+    command: "/usr/bin/expect /home/app/command.sh"
+    build: ../../docker
+    expose:
+      - "8081"  #  POKT RPC
+      - "26657" #  Tendermint RPC
+      - "26656" #  Tendermint Peers
+      - "46656" #  Tendermint Peers
+    environment:
+      POCKET_CORE_KEY: "44cb0f6fcaac7bb3199bcb3c8548dbebeeef9746441449db1515a3f890ccfcf24f26a1d836d8d421007bcb20a67b4afc70511cac6a0975347e430140d80741ee"
+      POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
+    networks:
+      - pocket
+    volumes:
+        - "./chains.json:/home/app/.pocket/chains.json"
+        - "./genesis.json:/home/app/.pocket/genesis.json"
+
+  pocket-core-testnet4:
+    image: poktnetwork/pocket-core:${ENV:-staging-latest}
+    privileged: true
+    command: "/usr/bin/expect /home/app/command.sh"
+    build: ../../docker
+    expose:
+      - "8081"  #  POKT RPC
+      - "26657" #  Tendermint RPC
+      - "26656" #  Tendermint Peers
+      - "46656" #  Tendermint Peers
+    environment:
+      POCKET_CORE_KEY: "11c1eb0da2fd2bc6aef9ab45cb2576807cd00e4147ea8388900860a2eed236078ab9c7a3b341bc071ad2f11e84c695812fe5c2771524b89ae1131cae48d93c8f"
+      POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
+    networks:
+      - pocket
+    volumes:
+        - "./chains.json:/home/app/.pocket/chains.json"
+        - "./genesis.json:/home/app/.pocket/genesis.json"
+
+  pocket-core-testnet5:
+    image: poktnetwork/pocket-core:${ENV:-staging-latest}
+    privileged: true
+    command: "/usr/bin/expect /home/app/command.sh"
+    build: ../../docker
+    expose:
+      - "8081"  #  POKT RPC
+      - "26657" #  Tendermint RPC
+      - "26656" #  Tendermint Peers
+      - "46656" #  Tendermint Peers
+    environment:
+      POCKET_CORE_KEY: "b7f2d96ef6f3b7b7e54fdf9dba81e3912c7d45d43785138c3be47c885009d3e09b1be29dd2c546244f13d9cb3abf9202707494286bf8d440f3e75f6dba30c57a"
+      POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656"
+    networks:
+      - pocket
+    volumes:
+        - "./chains.json:/home/app/.pocket/chains.json"
+        - "./genesis.json:/home/app/.pocket/genesis.json"
+
+volumes:
+  geth-mainnet:
+  geth-rinkeby:
+
+networks:
+  pocket:
+    driver: bridge

--- a/docker-compose/geth/docker-compose.yml
+++ b/docker-compose/geth/docker-compose.yml
@@ -22,22 +22,23 @@ services:
       - "30303"
     volumes:
       - geth-mainnet:/.mainnet
-    command: "--rpc  --rpcapi eth,net --rpcaddr 0.0.0.0 --rpcport 8545 --rpcvhosts=* --syncmode fast --datadir .mainnet --verbosity 3" 
+    command: "--rpc  --rpcapi eth,net --rpcaddr 0.0.0.0 --rpcport 8545 --rpcvhosts=* --syncmode fast --datadir .mainnet --verbosity 3"
     networks:
       - pocket
 
   pocket-core-testnet:
     image: poktnetwork/pocket-core:${ENV:-staging-latest}
     privileged: true
-    command: "/usr/bin/expect /home/app/command.sh" 
+    command: "/usr/bin/expect /home/app/command.sh"
     build: ../../docker
     expose:
       - "8081"  #  POKT RPC
       - "26657" #  Tendermint RPC
+      - "26656" #  Tendermint Peers
       - "46656" #  Tendermint Peers
     environment:
-      POCKET_CORE_KEY: "b8a56dead392e2b57eaba988068d0cedc0a11b9a16ca9610b094ec31a9cbc06650220553e5ccf56a863eaed88ebf1487e1dcb20e7fffbe0fb841cab1bb76af4d" 
-      POCKET_CORE_PERSISTENT_PEERS: "3C4CE33E68A726BCA3801E99E24F80C10EAF343C@pocket-core-testnet2:46656,  4BCB7B0E9C3FC3343905260BF36D40979BE524CD@pocket-core-testnet3:46656, E1EC5FBE826BB6DD3CEB04B33BBF221E611C601E@pocket-core-testnet4:46656, 8ED7A41B06EA855FF4BA3EE630688B73499626AE@pocket-core-testnet5:46656"
+      POCKET_CORE_KEY: "b8a56dead392e2b57eaba988068d0cedc0a11b9a16ca9610b094ec31a9cbc06650220553e5ccf56a863eaed88ebf1487e1dcb20e7fffbe0fb841cab1bb76af4d"
+      POCKET_CORE_SEEDS: "3C4CE33E68A726BCA3801E99E24F80C10EAF343C@pocket-core-testnet2:26656,  4BCB7B0E9C3FC3343905260BF36D40979BE524CD@pocket-core-testnet3:26656, E1EC5FBE826BB6DD3CEB04B33BBF221E611C601E@pocket-core-testnet4:26656, 8ED7A41B06EA855FF4BA3EE630688B73499626AE@pocket-core-testnet5:26656"
     networks:
       - pocket
     volumes:
@@ -48,25 +49,25 @@ services:
     extends: pocket-core-testnet
     environment:
       POCKET_CORE_KEY: "a49ff628a250c2d8e9a8e6dff2c86c075a5f0b22c489ac5d8a0b47392b02052bff1e6080925587cd76974710b14d1c2229aed4442921ccd67b7c97fece399ebe"
-      POCKET_CORE_PERSISTENT_PEERS: "3DC42932FF52F9F506DCE1D75B634DDAD654E22E@pocket-core-testnet:46656,  4BCB7B0E9C3FC3343905260BF36D40979BE524CD@pocket-core-testnet3:46656, E1EC5FBE826BB6DD3CEB04B33BBF221E611C601E@pocket-core-testnet4:46656, 8ED7A41B06EA855FF4BA3EE630688B73499626AE@pocket-core-testnet5:46656"
+      POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
 
   pocket-core-testnet3:
     extends: pocket-core-testnet
     environment:
       POCKET_CORE_KEY: "44cb0f6fcaac7bb3199bcb3c8548dbebeeef9746441449db1515a3f890ccfcf24f26a1d836d8d421007bcb20a67b4afc70511cac6a0975347e430140d80741ee"
-      POCKET_CORE_PERSISTENT_PEERS: "3DC42932FF52F9F506DCE1D75B634DDAD654E22E@pocket-core-testnet:46656,  3C4CE33E68A726BCA3801E99E24F80C10EAF343C@pocket-core-testnet2:46656, E1EC5FBE826BB6DD3CEB04B33BBF221E611C601E@pocket-core-testnet4:46656, 8ED7A41B06EA855FF4BA3EE630688B73499626AE@pocket-core-testnet5:46656"
+      POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
 
   pocket-core-testnet4:
     extends: pocket-core-testnet
     environment:
       POCKET_CORE_KEY: "11c1eb0da2fd2bc6aef9ab45cb2576807cd00e4147ea8388900860a2eed236078ab9c7a3b341bc071ad2f11e84c695812fe5c2771524b89ae1131cae48d93c8f"
-      POCKET_CORE_PERSISTENT_PEERS: "3DC42932FF52F9F506DCE1D75B634DDAD654E22E@pocket-core-testnet:46656,  3C4CE33E68A726BCA3801E99E24F80C10EAF343C@pocket-core-testnet2:46656, 4BCB7B0E9C3FC3343905260BF36D40979BE524CD@pocket-core-testnet3:46656, 8ED7A41B06EA855FF4BA3EE630688B73499626AE@pocket-core-testnet5:46656"
+      POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, 8ed7a41b06ea855ff4ba3ee630688b73499626ae@pocket-core-testnet5:26656"
 
   pocket-core-testnet5:
     extends: pocket-core-testnet
     environment:
       POCKET_CORE_KEY: "b7f2d96ef6f3b7b7e54fdf9dba81e3912c7d45d43785138c3be47c885009d3e09b1be29dd2c546244f13d9cb3abf9202707494286bf8d440f3e75f6dba30c57a"
-      POCKET_CORE_PERSISTENT_PEERS: "3DC42932FF52F9F506DCE1D75B634DDAD654E22E@pocket-core-testnet:46656,  3C4CE33E68A726BCA3801E99E24F80C10EAF343C@pocket-core-testnet2:46656, 4BCB7B0E9C3FC3343905260BF36D40979BE524CD@pocket-core-testnet3:46656, E1EC5FBE826BB6DD3CEB04B33BBF221E611C601E@pocket-core-testnet4:46656"
+      POCKET_CORE_SEEDS: "3dc42932ff52f9f506dce1d75b634ddad654e22e@pocket-core-testnet:26656,  3c4ce33e68a726bca3801e99e24f80c10eaf343c@pocket-core-testnet2:26656, 4bcb7b0e9c3fc3343905260bf36d40979be524cd@pocket-core-testnet3:26656, e1ec5fbe826bb6dd3ceb04b33bbf221e611c601e@pocket-core-testnet4:26656"
 
 volumes:
   geth-mainnet:

--- a/docker-compose/geth/genesis.json
+++ b/docker-compose/geth/genesis.json
@@ -1,5 +1,5 @@
 {
-  "genesis_time": "0001-01-01T00:00:00Z",
+  "genesis_time": "2020-02-03T18:45:00Z",
   "chain_id": "pocket-test",
   "consensus_params": {
     "block": {

--- a/docker/command.sh
+++ b/docker/command.sh
@@ -9,7 +9,7 @@ if { $env(POCKET_CORE_KEY) eq "" }  {
     sleep 1
     send -- "yo\n"
     expect eof
-    spawn pocket-core start --seeds env(POCKET_CORE_SEEDS)
+    spawn pocket-core start --seeds $env(POCKET_CORE_SEEDS)
 }
 
 sleep 1

--- a/docker/command.sh
+++ b/docker/command.sh
@@ -9,7 +9,7 @@ if { $env(POCKET_CORE_KEY) eq "" }  {
     sleep 1
     send -- "yo\n"
     expect eof
-    spawn pocket-core start --persistent_peers $env(POCKET_CORE_PERSISTENT_PEERS)
+    spawn pocket-core start --seeds env(POCKET_CORE_SEEDS)
 }
 
 sleep 1


### PR DESCRIPTION
Resolves #72 

- change command.sh to use --seeds instead of --persistnet_peers
- Add local setup for geth exposing RPC ports for a node