### PR TITLE
patch/specify-genesis-time

### DIFF
--- a/testnet-playground/config_generator/main.go
+++ b/testnet-playground/config_generator/main.go
@@ -63,7 +63,7 @@ func keys(n int) []JSONKeys {
 
 func genesis(keys []JSONKeys) {
 	j, er := types.ModuleCdc.MarshalJSONIndent(tmTypes.GenesisDoc{
-		GenesisTime: time.Time{},
+		GenesisTime: time.Now(),
 		ChainID:     "pocket-test",
 		ConsensusParams: &tmTypes.ConsensusParams{
 			Block: tmTypes.BlockParams{


### PR DESCRIPTION
Resolves #74 

- change Genesis Time to `time.Now` instead of `time.Time`