### PR TITLE
[RFC] docker/entrypoint.sh: Allow to load config/keys/passphrase from file

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,4 +16,28 @@ if [ -n "${POCKET_CORE_CONFIG}" ] ; then
     echo "${POCKET_CORE_CONFIG}" > /home/app/.pocket/config/config.json
 fi
 
+# Allowing to distribute those files through a shared r/o volume for example
+# (like Vault sidecar)
+
+if [ -f "${POCKET_CORE_GENESIS_PATH}" ] ; then
+    cp -f ${POCKET_CORE_GENESIS_PATH} /home/app/.pocket/config/genesis.json
+fi
+
+if [ -f "${POCKET_CORE_CHAINS_PATH}" ] ; then
+    cp -f ${POCKET_CORE_CHAINS_PATH} /home/app/.pocket/config/chains.json
+fi
+
+if [ -f "${POCKET_CORE_CONFIG_PATH}" ] ; then
+    cp -f ${POCKET_CORE_CONFIG_PATH} /home/app/.pocket/config/config.json
+fi
+
+if [ -f "${POCKET_CORE_KEY_FILE}" ] ; then
+    export POCKET_CORE_KEY=$(cat ${POCKET_CORE_KEY_FILE} )
+fi
+
+if [ -f "${POCKET_CORE_PASSPHRASE_FILE}" ] ; then
+    export POCKET_CORE_PASSPHRASE=$(cat ${POCKET_CORE_PASSPHRASE_FILE} )
+fi
+
+
 /usr/bin/expect /home/app/command.sh $@


### PR DESCRIPTION
We're working on an helm chart, and we've encoutered two issues this PR is trying to fix:
- We want to store the keys and passphrase in Vault and inject the content via the kubernetes vault sidecar, which can only inject files
- Loading the genesis.json from an env var is a problem because the total chart size is very limited. 
