### PR TITLE
push multiple tags to docker hub

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,8 +61,8 @@ COPY entrypoint.sh /tmp/
 COPY command.sh /tmp/
 RUN apk add --update --no-cache expect bash leveldb-dev
 # Create app user and add permissions
-RUN addgroup -S app \
-	&& adduser -S -G app app
+RUN addgroup --gid 1001 -S app \
+	&& adduser --uid 1005 -S -G app app
 RUN mv /tmp/entrypoint.sh /home/app/ && mv /tmp/command.sh /home/app/command.sh && chown -R app /bin/pocket  && mkdir -p /home/app/.pocket/config && chown -R app /home/app/.pocket
 USER app
 

--- a/docker/command.sh
+++ b/docker/command.sh
@@ -3,10 +3,16 @@
 set command $argv; # Grab the first command line parameter
 set timeout -1
 
+spawn sh -c "cp /tmp/*.json /home/app/.pocket/config/"
+sleep 2
 if { $env(POCKET_CORE_KEY) eq "" }  {
+    log_user 0
     spawn sh -c "$command"
+    send -- "$env(POCKET_CORE_PASSPHRASE)\n"
+    log_user 1
 
 } else {
+    log_user 0
     spawn pocket accounts import-raw $env(POCKET_CORE_KEY)
     sleep 1
     send -- "$env(POCKET_CORE_PASSPHRASE)\n"
@@ -15,12 +21,9 @@ if { $env(POCKET_CORE_KEY) eq "" }  {
     sleep 1
     send -- "$env(POCKET_CORE_PASSPHRASE)\n"
     expect eof
+    log_user 1
     spawn sh -c "$command"
 }
-
-sleep 1
-
-send -- "$env(POCKET_CORE_PASSPHRASE)\n"
 
 expect eof
 

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -76,7 +76,13 @@ eval $TAG_COMMAND
 # Push the image
 
 if [[ "$BRANCH_NAME" = "RC-"* ]]; then
+    eval "docker tag pocket-core-$DOCKER_TAG:latest $DOCKER_IMAGE_NAME:$BRANCH_NAME"
     eval "docker push $DOCKER_IMAGE_NAME:$BRANCH_NAME"
+fi
+
+if [[ "$BRANCH_NAME" = "staging" ]]; then
+    eval "docker tag pocket-core-$DOCKER_TAG:latest $DOCKER_IMAGE_NAME:devnet-$CIRCLE_BUILD_NUM"
+    eval "docker push $DOCKER_IMAGE_NAME:devnet-$CIRCLE_BUILD_NUM"
 fi
 
 


### PR DESCRIPTION
command.sh
- Prevent private key from showing in docker logs
- Remove send password at the end of script

push.sh
- Add new tag based on build-id
- Add RCs tagging

Dockerfile
- Add uid and gid when creating the user and group 'App'

