### PR TITLE
Use pattern for /v1 Pocket node nginx location

### DIFF
--- a/docker-compose/stacks/pocket-validator/proxy/conf.d/https.conf.template
+++ b/docker-compose/stacks/pocket-validator/proxy/conf.d/https.conf.template
@@ -33,7 +33,7 @@ server {
      ssl_stapling on;
      ssl_stapling_verify on;
 
-     location /v1 {
+     location ~ ^/v1/?$ {
        set $node1 node1:8081;
        proxy_pass http://$node1;
        proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
NGINX locations are greedy, so `location /v1 {}` matches calls to `/v1` as well as calls to locations such as `/v1/query/balance`. If the purpose of using the multiple locations in `https.conf.template` is to limit calls RPC to `/v1` and the three `/v1/client/` locations, then leaving `/v1` means that calls to other locations (e.g. `/v1/query/balance`) under `/v1` will still reach the RPC server. This PR changes it to a pattern so that it will only match calls specifically to `/v1` and `/v1/`.